### PR TITLE
Fix loading of role default variables

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: add distribution-specific variables
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars: "../defaults/{{ ansible_distribution }}.yml"
 
 - name: add backports repository
   apt_repository: repo='deb {{backports_uri}} {{backports_components}}' state=present update_cache=yes


### PR DESCRIPTION
Recently, the variables were moved to make them overridable. However, it
was forgotten to change the code responsible for the inclusion of these
variables. Accordingly, this commit fixes this regression.

Relates c2595805c9d2a0424cf75e01f780b4580ea358f5
Relates #2