### PR TITLE
Add option to overwrite backports_components/uri

### DIFF
--- a/defaults/Debian.yml
+++ b/defaults/Debian.yml
@@ -1,3 +1,5 @@
 ---
-backports_uri: http://deb.debian.org/debian
-backports_components: "{{backports_distribution}}-backports main contrib non-free"
+backports_uri: https://deb.debian.org/debian
+backports_components: "{{ backports_distribution }}-backports main contrib non-free"
+backports_additional_packages:
+  - apt-transport-https

--- a/defaults/Ubuntu.yml
+++ b/defaults/Ubuntu.yml
@@ -1,3 +1,4 @@
 ---
 backports_uri: https://archive.ubuntu.com/ubuntu
-backports_components: "{{backports_distribution}}-backports main restricted universe multiverse"
+backports_components: "{{ backports_distribution }}-backports main restricted universe multiverse"
+backports_additional_packages: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,9 @@
 ---
-backports_distribution: "{{ansible_distribution_release}}"
+backports_distribution: "{{ ansible_distribution_release }}"
 backports_priority_enabled: false
 backports_priority: 100
 backports_state: 'present'
+# A string for example http://deb.debian.org/debian
+backports_external_uri: ""
+# Components in a string such as "{{ backports_distribution }}-backports main restricted universe multiverse"
+backports_external_components: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,22 @@
 - name: add distribution-specific variables
   include_vars: "../defaults/{{ ansible_distribution }}.yml"
 
+- name: install additional packages
+  apt:
+    pkg: "{{ backports_additional_packages }}"
+    state: present
+  when: backports_additional_packages | length > 0
+
+- name: overwrite backports_uri with backports_external_uri
+  set_fact:
+    backports_uri: "{{ backports_external_uri }}"
+  when: backports_external_uri | length > 0
+
+- name: overwrite backports_components with backports_external_components
+  set_fact:
+    backports_components: "{{ backports_external_components }}"
+  when: backports_external_components | length > 0
+
 - name: add backports repository
   apt_repository:
     repo: deb {{ backports_uri }} {{ backports_components }}


### PR DESCRIPTION
* This commit allows passing an uri and component variable
which will overwrite the defaults in Ubuntu/Debian.yml

* This commit sets sane defaults for newer debian versions,
which means it installs apt-https-transports package
and uses the https:// backport uri by default
instead of http://

* Closes #14

Should be merged after #16 