### PR TITLE
Add option to overwrite role internal components and uri vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ tasks:
 ## Variables
 
 - `backports_uri`: URI of the backports repository; change this if you want to use a particular mirror.
-  - Debian: `http://deb.debian.org/debian`
+  - Debian: `https://deb.debian.org/debian`
   - Ubuntu: `http://archive.ubuntu.com/ubuntu`
 - `backports_components`: Release and components for sources.list
-  - Debian: `{{backports_distribution}}-backports backports main contrib non-free`
-  - Ubuntu: `{{backports_distribution}}-backports main restricted universe multiverse`
+  - Debian: `{{ backports_distribution }}-backports backports main contrib non-free`
+  - Ubuntu: `{{ backports_distribution }}-backports main restricted universe multiverse`
 - `backports_state`: Whether the backports repository should be used; default `'present'`, change to `'absent'` to disable the role.
 - `backports_priority_enabled`: Whether to enable backports priority (APT pinning); default `false`.
 - `backports_priority`: Set pin priority for the backports repository; default `100`. See more at [`AptConfiguration` page](https://wiki.debian.org/AptConfiguration).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ tasks:
 ## Variables
 
 - `backports_uri`: URI of the backports repository; change this if you want to use a particular mirror.
-  - Debian: `https://deb.debian.org/debian`
+  - Debian: `http://deb.debian.org/debian`
   - Ubuntu: `http://archive.ubuntu.com/ubuntu`
 - `backports_components`: Release and components for sources.list
   - Debian: `{{ backports_distribution }}-backports backports main contrib non-free`

--- a/defaults/Debian.yml
+++ b/defaults/Debian.yml
@@ -1,5 +1,4 @@
 ---
-backports_internal_uri: https://deb.debian.org/debian
+backports_internal_uri: http://deb.debian.org/debian
 backports_internal_components: "{{ backports_distribution }}-backports main contrib non-free"
-backports_internal_additional_packages:
-  - apt-transport-https
+backports_internal_additional_packages: []

--- a/defaults/Debian.yml
+++ b/defaults/Debian.yml
@@ -1,3 +1,5 @@
 ---
-backports_uri: http://deb.debian.org/debian
-backports_components: "{{backports_distribution}}-backports main contrib non-free"
+backports_internal_uri: https://deb.debian.org/debian
+backports_internal_components: "{{ backports_distribution }}-backports main contrib non-free"
+backports_internal_additional_packages:
+  - apt-transport-https

--- a/defaults/Ubuntu.yml
+++ b/defaults/Ubuntu.yml
@@ -1,3 +1,4 @@
 ---
-backports_uri: http://archive.ubuntu.com/ubuntu
-backports_components: "{{backports_distribution}}-backports main restricted universe multiverse"
+backports_internal_uri: http://archive.ubuntu.com/ubuntu
+backports_internal_components: "{{ backports_distribution }}-backports main restricted universe multiverse"
+backports_internal_additional_packages: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,9 @@
 ---
-backports_distribution: "{{ansible_distribution_release}}"
+backports_distribution: "{{ ansible_distribution_release }}"
 backports_priority_enabled: false
 backports_priority: 100
 backports_state: 'present'
+# A string for example http://deb.debian.org/debian
+backports_uri: ""
+# Components in a string such as "{{ backports_distribution }}-backports main restricted universe multiverse"
+backports_components: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,9 +2,25 @@
 - name: add distribution-specific variables
   include_vars: "../defaults/{{ ansible_distribution }}.yml"
 
+- name: install additional packages
+  apt:
+    pkg: "{{ backports_internal_additional_packages }}"
+    state: present
+  when: backports_internal_additional_packages | length > 0
+
+- name: overwrite backports_internal_uri with backports_uri
+  set_fact:
+    backports_internal_uri: "{{ backports_uri }}"
+  when: backports_uri | length > 0
+
+- name: overwrite backports_internal_components with backports_components
+  set_fact:
+    backports_internal_components: "{{ backports_components }}"
+  when: backports_components | length > 0
+
 - name: add backports repository
   apt_repository:
-    repo: deb {{ backports_uri }} {{ backports_components }}
+    repo: deb {{ backports_internal_uri }} {{ backports_internal_components }}
     state: "{{ backports_state }}"
     update_cache: yes
 


### PR DESCRIPTION
Reverse logic:

* This commit allows passing an uri and component variable
  which will overwrite the internal defaults in Ubuntu/Debian.yml

* This commit sets sane defaults for newer debian versions,
  which means it installs apt-https-transports package
  and uses the https:// backport_internal_uri by default
  instead of http://

* Closes #14

Should be merged after #16